### PR TITLE
Gilbert's suggestion

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -40,26 +40,35 @@ include::{common-includes}/gitclone.adoc[]
 
 In Jakarta Data an entity defines the structure for persisting a piece of data. This structure is represented by a Java object and it's associated fields. Start by creating a simple record class.
 
-[role="code_command hotspot", subs="quotes"]
+[role="code_command hotspot file=0", subs="quotes"]
 ----
 #Create the `Package` class.#
 `src/main/java/io/openliberty/guides/data/Package.java`
 ----
 
+Package.java
+[source, Java, linenums, role='code_column hide_tags=copyright']
+----
+include::src/main/java/io/openliberty/guides/data/Package.java[]
+----
+
 This is a very simple entity, with only a single field `id`.
 
-Repositories in Jakarta Data provide a simplified means for interacting with persistent data. Jakarta Data provides several built in Repositories with common methods which can be extended. The `CrudRepository` interface provides methods for Create, Read, Update, and Delete (CRUD) operations.
-
 //TODO Packages or PackageRepository?
+[role="code_command hotspot file=1", subs="quotes"]
 ----
 #Create the `Packages.java` class.#
 `src/main/java/io/openliberty/guides/data/Packages.java`
 ----
+
 Packages.java
-[source, Java, linenums, role='code_column hide_tags=query-by-method-step3,query-by-method-step2']
+[source, Java, linenums, role='code_column hide_tags=copyright,query-by-method-step2,query-by-method-step3']
 ----
 include::finish/src/main/java/io/openliberty/guides/data/Packages.java[]
 ----
+
+Repositories in Jakarta Data provide a simplified means for interacting with persistent data. Jakarta Data provides several built in Repositories with common methods which can be extended. The [hotspot=CrudRepository file=1]`CrudRepository` interface provides methods for Create, Read, Update, and Delete (CRUD) operations.
+
 
 With some text
 

--- a/README.adoc
+++ b/README.adoc
@@ -12,8 +12,8 @@
 :page-releasedate: 2024-01-01
 :page-majorupdateddate: 2023-01-01
 :page-description: Description - TODO
-:page-tags: ['']
-:page-related-guides: ['', ']
+:page-tags: ['jakarta-ee']
+:page-related-guides: []
 :page-permalink: /guides/{projectid}
 :common-includes: https://raw.githubusercontent.com/OpenLiberty/guides-common/prod
 :source-highlighter: prettify

--- a/finish/src/main/java/io/openliberty/guides/data/Package.java
+++ b/finish/src/main/java/io/openliberty/guides/data/Package.java
@@ -1,3 +1,14 @@
+// tag::copyright[]
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+// end::copyright[]
 package io.openliberty.guides.data;
 
 import jakarta.json.Json;

--- a/finish/src/main/java/io/openliberty/guides/data/Packages.java
+++ b/finish/src/main/java/io/openliberty/guides/data/Packages.java
@@ -1,3 +1,14 @@
+// tag::copyright[]
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+// end::copyright[]
 package io.openliberty.guides.data;
 
 import java.util.List;
@@ -6,7 +17,9 @@ import jakarta.data.repository.CrudRepository;
 import jakarta.data.repository.Repository;
 
 @Repository
+// tag::CrudRepository[]
 public interface Packages extends CrudRepository<Package, Integer> {
+// end::CrudRepository[]
 
     // tag::query-by-method-step1[]
     List<Package> findByLengthGreaterThan(float length);
@@ -17,6 +30,6 @@ public interface Packages extends CrudRepository<Package, Integer> {
 
     // tag::query-by-method-step3[]
     List<Package> findByHeightBetween(float minHeight, float maxHeight);
-    // tag::query-by-method-step3[]
+    // end::query-by-method-step3[]
 
 }


### PR DESCRIPTION
- because having 2 files in a section, need to specify the `file` index
- better put the `source` definition after the `code_command` definition
- java file should have the license info but in the README, hide it
- there is a typo for the `query-by-method-step3` hotspot end tag 
- added `CrudRepository` hotspot tag to showcase how the hotspot works